### PR TITLE
Allowed channel to be integer as string

### DIFF
--- a/src/GoSMS/GoSMS.php
+++ b/src/GoSMS/GoSMS.php
@@ -327,7 +327,7 @@ class GoSMS
      */
     public function setChannel($channel)
     {
-        if ( ! is_int($channel) || ( $channel < 0 ) ) {
+        if ( ! strval(intval($channel)) == $channel || ( $channel < 0 ) ) {
             throw new GoSMSException\InvalidChannel('Invalid channel');
         }
 


### PR DESCRIPTION
If used on frameworks like Laravel, channel is stored in .env file and provided to controller by config file. In this case, although in .env is integer e.g. 
`GO_SMS_CHANNEL=1234`
, it is parsed as string
`$sms->setChannel(config('gosms.channel')); // config(...) returns string`

By this pull I'm parsing this string to int and then comparing thats int string value to the int value itself = in config is stored just number